### PR TITLE
Delayed Tasks

### DIFF
--- a/pool_test.go
+++ b/pool_test.go
@@ -6,26 +6,32 @@ import (
 	"time"
 
 	"github.com/fortytw2/thermocline"
-	"github.com/fortytw2/thermocline/brokers/mem"
 )
 
 func TestPool(t *testing.T) {
 	t.Parallel()
 
-	var b thermocline.Broker
-	b = mem.NewBroker()
+	testPool(t, 0)
+}
 
+func TestPoolSlowWorkers(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skip("skipping in short mode.")
+	}
+	testPool(t, 250*time.Millisecond)
+}
+
+func testPool(t *testing.T, duration time.Duration) {
+	b, _, writer := SetupBroker(t)
 	ticker := time.NewTicker(time.Millisecond * 10)
 	go func() {
-		w, err := b.Write("test", thermocline.NoVersion)
-		if err != nil {
-			t.Fatalf("cannot get write chan %s", err)
-		}
 		for {
 			select {
 			case t := <-ticker.C:
 				tk, _ := thermocline.NewTask(t)
-				w <- tk
+				writer <- tk
 			}
 		}
 	}()
@@ -33,6 +39,7 @@ func TestPool(t *testing.T) {
 	var worked int64
 	p, err := thermocline.NewPool("test", thermocline.NoVersion, b, func(task *thermocline.Task) ([]*thermocline.Task, error) {
 		atomic.AddInt64(&worked, 1)
+		time.Sleep(duration)
 		return nil, nil
 	}, 5)
 	if err != nil {
@@ -66,73 +73,4 @@ func TestPool(t *testing.T) {
 	if a := atomic.LoadInt64(&worked); a <= 295 {
 		t.Errorf("more than 295-ish tasks should be worked, %d", a)
 	}
-}
-
-func TestPoolSlowWorkers(t *testing.T) {
-	t.Parallel()
-
-	var b thermocline.Broker
-	b = mem.NewBroker()
-
-	ticker := time.NewTicker(time.Millisecond * 10)
-	go func() {
-		w, err := b.Write("test", thermocline.NoVersion)
-		if err != nil {
-			t.Fatalf("cannot get write chan %s", err)
-		}
-		for {
-			select {
-			case t := <-ticker.C:
-				tk, _ := thermocline.NewTask(t)
-				w <- tk
-			}
-		}
-	}()
-
-	var worked int64
-	p, err := thermocline.NewPool("test", thermocline.NoVersion, b, func(task *thermocline.Task) ([]*thermocline.Task, error) {
-		time.Sleep(150 * time.Millisecond)
-		atomic.AddInt64(&worked, 1)
-		return nil, nil
-	}, 5)
-	if err != nil {
-		t.Errorf("cannot create pool %s", err)
-	}
-
-	time.Sleep(1 * time.Second)
-	err = p.Add(120)
-	if err != nil {
-		t.Errorf("cannot add workers, %s", err)
-	}
-
-	if p.Len() != 125 {
-		t.Errorf("pool length is not 125! - %d", p.Len())
-	}
-
-	time.Sleep(1 * time.Second)
-	err = p.Add(-65)
-	if err != nil {
-		t.Errorf("cannot remove workers, %s", err)
-	}
-
-	if p.Len() != 60 {
-		t.Errorf("pool length is not 60! - %d", p.Len())
-	}
-
-	time.Sleep(1 * time.Second)
-	ticker.Stop()
-
-	err = p.Stop()
-	if err != nil {
-		t.Errorf("cannot stop pool, %s", err)
-	}
-
-	if p.Len() != 0 {
-		t.Errorf("pool length is not 0! - %d", p.Len())
-	}
-
-	if a := atomic.LoadInt64(&worked); a <= 295 {
-		t.Errorf("more than 295-ish tasks should be worked, %d", a)
-	}
-
 }

--- a/task_test.go
+++ b/task_test.go
@@ -1,0 +1,73 @@
+package thermocline_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fortytw2/thermocline"
+	"github.com/fortytw2/thermocline/brokers/mem"
+)
+
+func TestDelayedTask(t *testing.T) {
+	t.Parallel()
+
+	var b thermocline.Broker
+	b = mem.NewBroker()
+
+	reader, err := b.Read("test", thermocline.NoVersion)
+	if err != nil {
+		t.Errorf("could not open queue '%s'", err)
+	}
+
+	writer, err := b.Write("test", thermocline.NoVersion)
+	if err != nil {
+		t.Errorf("could not open queue '%s'", err)
+	}
+
+	task, err := thermocline.NewDelayedTask("task infos", time.Second)
+	if err != nil {
+		t.Errorf("could not make delayed task, %s", err)
+	}
+
+	before := time.Now()
+	writer <- task
+
+	<-reader
+	after := time.Now()
+
+	if after.Sub(before) <= time.Second {
+		t.Fatalf("task appeared before duration!")
+	}
+}
+
+func TestLongDelayedTask(t *testing.T) {
+	t.Parallel()
+
+	var b thermocline.Broker
+	b = mem.NewBroker()
+
+	reader, err := b.Read("test", thermocline.NoVersion)
+	if err != nil {
+		t.Errorf("could not open queue '%s'", err)
+	}
+
+	writer, err := b.Write("test", thermocline.NoVersion)
+	if err != nil {
+		t.Errorf("could not open queue '%s'", err)
+	}
+
+	task, err := thermocline.NewDelayedTask("task infos", time.Second*10)
+	if err != nil {
+		t.Errorf("could not make delayed task, %s", err)
+	}
+
+	before := time.Now()
+	writer <- task
+
+	<-reader
+	after := time.Now()
+
+	if after.Sub(before) <= time.Second*10 {
+		t.Fatalf("task appeared before duration!")
+	}
+}

--- a/task_test.go
+++ b/task_test.go
@@ -5,24 +5,12 @@ import (
 	"time"
 
 	"github.com/fortytw2/thermocline"
-	"github.com/fortytw2/thermocline/brokers/mem"
 )
 
 func TestDelayedTask(t *testing.T) {
 	t.Parallel()
 
-	var b thermocline.Broker
-	b = mem.NewBroker()
-
-	reader, err := b.Read("test", thermocline.NoVersion)
-	if err != nil {
-		t.Errorf("could not open queue '%s'", err)
-	}
-
-	writer, err := b.Write("test", thermocline.NoVersion)
-	if err != nil {
-		t.Errorf("could not open queue '%s'", err)
-	}
+	_, reader, writer := SetupBroker(t)
 
 	task, err := thermocline.NewDelayedTask("task infos", time.Second)
 	if err != nil {
@@ -43,18 +31,11 @@ func TestDelayedTask(t *testing.T) {
 func TestLongDelayedTask(t *testing.T) {
 	t.Parallel()
 
-	var b thermocline.Broker
-	b = mem.NewBroker()
-
-	reader, err := b.Read("test", thermocline.NoVersion)
-	if err != nil {
-		t.Errorf("could not open queue '%s'", err)
+	if testing.Short() {
+		t.Skip("skipping in short mode.")
 	}
 
-	writer, err := b.Write("test", thermocline.NoVersion)
-	if err != nil {
-		t.Errorf("could not open queue '%s'", err)
-	}
+	_, reader, writer := SetupBroker(t)
 
 	task, err := thermocline.NewDelayedTask("task infos", time.Second*10)
 	if err != nil {

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,26 @@
+package thermocline_test
+
+import (
+	"testing"
+
+	"github.com/fortytw2/thermocline"
+	"github.com/fortytw2/thermocline/brokers/mem"
+)
+
+// SetupBroker is a test utility function
+func SetupBroker(t *testing.T) (thermocline.Broker, <-chan *thermocline.Task, chan<- *thermocline.Task) {
+	var broker thermocline.Broker
+	broker = mem.NewBroker()
+
+	reader, err := broker.Read("test", thermocline.NoVersion)
+	if err != nil {
+		t.Errorf("could not open queue '%s'", err)
+	}
+
+	writer, err := broker.Write("test", thermocline.NoVersion)
+	if err != nil {
+		t.Errorf("could not open queue '%s'", err)
+	}
+
+	return broker, reader, writer
+}

--- a/worker_test.go
+++ b/worker_test.go
@@ -17,18 +17,7 @@ import (
 func TestWorker(t *testing.T) {
 	t.Parallel()
 
-	var broker thermocline.Broker
-	broker = mem.NewBroker()
-
-	reader, err := broker.Read("test", thermocline.NoVersion)
-	if err != nil {
-		t.Errorf("could not open queue '%s'", err)
-	}
-
-	writer, err := broker.Write("test", thermocline.NoVersion)
-	if err != nil {
-		t.Errorf("could not open queue '%s'", err)
-	}
+	_, reader, writer := SetupBroker(t)
 
 	tn := rand.Intn(256)
 	//TODO(fortytw2): don't use iter for tests, even though it's nice


### PR DESCRIPTION
Enable setting a `time.Duration` after which the task is created that it can be worked. Current implementation should be safe for low-volume usage
